### PR TITLE
Feature - Filename Flags

### DIFF
--- a/src/commands/make-action.js
+++ b/src/commands/make-action.js
@@ -2,6 +2,8 @@ const program = require('commander');
 const path = require('path');
 const template = require('lodash.template');
 const snakeCase = require('lodash.snakecase');
+const lowercase = require('lodash.tolower');
+const kebab = require('lodash.kebabcase');
 const uppercase = require('lodash.toupper');
 const utils = require('../utils');
 const paths = require('../paths');
@@ -9,12 +11,16 @@ const paths = require('../paths');
 program
   .command('make:action')
   .option('--items [list]', 'Add action items', utils.list, ['testAction'])
+  .option('--name [name]', 'Set filename for actions file', 'actions')
   .action(options => {
     const insertPath = path.join(options.parent.root, options.parent.path);
+    const fileName = lowercase(kebab(options.name));
 
     utils.info('Creating action...');
-    utils.exists('actions.js')
-      .then(() => utils.exit('A action in this directory already exists.'))
+    utils.exists(`${fileName}.js`)
+      .then(() => utils.exit(
+        `Actions file with filename "${fileName}.js" already exists.`
+      ))
       .catch(() => utils.read(paths.actionStub, 'utf8'))
       .then(content => Promise.resolve(
         template(content)({
@@ -24,7 +30,9 @@ program
             .map(uppercase),
         })
       ))
-      .then(content => utils.write(`${insertPath}actions.js`, content))
-      .then(() => utils.success('Action successfully created!'))
+      .then(content => utils.write(`${insertPath}${fileName}.js`, content))
+      .then(() => utils.success(
+        `Actions file successfully created! ==> "${insertPath}${fileName}.js"`
+      ))
       .catch(utils.exit);
   });

--- a/src/commands/make-container.js
+++ b/src/commands/make-container.js
@@ -13,7 +13,7 @@ program
     const insertPath = path.join(options.parent.root, options.parent.path);
     const fileName = `${lowercase(kebab(name))}.js`;
 
-    utils.info(`Creating container component "${name}" inside "${fileName}"...`);
+    utils.info(`Creating container component "${name}"...`);
     utils.exists(fileName)
       .then(() => utils.exit(`Container component "${name}" already exists.`))
       .catch(() => utils.read(paths.containerStub, 'utf8'))
@@ -25,7 +25,7 @@ program
       ))
       .then(content => utils.write(`${insertPath}/${fileName}`, content))
       .then(() => utils.success(
-        `Container component ${name} successfully created inside "${fileName}"!`
+        `Container component ${name} successfully created! ==> "${insertPath}${fileName}.js"`
       ))
       .catch(utils.exit);
   });

--- a/src/commands/make-reducer.js
+++ b/src/commands/make-reducer.js
@@ -1,25 +1,40 @@
 const program = require('commander');
 const path = require('path');
 const template = require('lodash.template');
+const lowercase = require('lodash.tolower');
+const kebab = require('lodash.kebabcase');
+const snakeCase = require('lodash.snakecase');
+const uppercase = require('lodash.toupper');
 const utils = require('../utils');
 const paths = require('../paths');
 
 program
   .command('make:reducer')
   .option('--items [list]', 'Add reducer items', utils.list, ['test'])
+  .option('--actions [list]', 'Add action types', utils.list, ['testAction'])
+  .option('--name [name]', 'Set filename for reducer file', 'reducer')
   .action(options => {
     const insertPath = path.join(options.parent.root, options.parent.path);
+    const fileName = lowercase(kebab(options.name));
+    const actionTypes = options.actions
+      .map(snakeCase)
+      .map(uppercase);
 
     utils.info('Creating reducer...');
-    utils.exists('reducer.js')
-      .then(() => utils.exit('A reducer in this directory already exists.'))
+    utils.exists(`${fileName}.js`)
+      .then(() => utils.exit(
+        `Reducer file with filename "${fileName}.js" already exists.`
+      ))
       .catch(() => utils.read(paths.reducerStub, 'utf8'))
       .then(content => Promise.resolve(
         template(content)({
+          actionTypes,
           reducers: options.items,
         })
       ))
-      .then(content => utils.write(`${insertPath}reducer.js`, content))
-      .then(() => utils.success('Reducer successfully created!'))
+      .then(content => utils.write(`${insertPath}${fileName}.js`, content))
+      .then(() => utils.success(
+        `Reducer file successfully created! ==> "${insertPath}${fileName}.js"`
+      ))
       .catch(utils.exit);
   });

--- a/src/commands/make-selector.js
+++ b/src/commands/make-selector.js
@@ -1,25 +1,33 @@
 const program = require('commander');
 const path = require('path');
 const template = require('lodash.template');
+const lowercase = require('lodash.tolower');
+const kebab = require('lodash.kebabcase');
 const utils = require('../utils');
 const paths = require('../paths');
 
 program
   .command('make:selector')
   .option('--items [list]', 'Add selector items', utils.list, ['testSelector'])
+  .option('--name [name]', 'Set filename for selectors file', 'selectors')
   .action(options => {
     const insertPath = path.join(options.parent.root, options.parent.path);
+    const fileName = lowercase(kebab(options.name));
 
     utils.info('Creating selector...');
-    utils.exists('selectors.js')
-      .then(() => utils.exit('A selector in this directory already exists.'))
+    utils.exists(`${fileName}.js`)
+      .then(() => utils.exit(
+        `Selectors file with filename "${fileName}.js" already exists.`
+      ))
       .catch(() => utils.read(paths.selectorStub, 'utf8'))
       .then(content => Promise.resolve(
         template(content)({
           selectors: options.items,
         })
       ))
-      .then(content => utils.write(`${insertPath}selectors.js`, content))
-      .then(() => utils.success('Selector successfully created!'))
+      .then(content => utils.write(`${insertPath}${fileName}.js`, content))
+      .then(() => utils.success(
+        `Selectors file successfully created! ==> "${insertPath}${fileName}.js"`
+      ))
       .catch(utils.exit);
   });

--- a/src/commands/make.js
+++ b/src/commands/make.js
@@ -3,6 +3,8 @@ const path = require('path');
 const template = require('lodash.template');
 const snakeCase = require('lodash.snakecase');
 const uppercase = require('lodash.toupper');
+const kebab = require('lodash.kebabcase');
+const lowercase = require('lodash.tolower');
 const utils = require('../utils');
 const paths = require('../paths');
 
@@ -13,11 +15,14 @@ program
   .option('--selectors [list]', 'Add selector items', utils.list, ['testSelector'])
   .action((name, options) => {
     const insertPath = path.join(options.parent.root, options.parent.path);
+    const folderName = lowercase(kebab(name));
 
     utils.info(`Creating state "${name}"...`);
-    utils.exists(name)
-      .then(() => utils.exit(`State "${name}" already exists.`))
-      .catch(() => utils.mkdir(`${insertPath}${name}`))
+    utils.exists(folderName)
+      .then(() => utils.exit(
+        `State folder with name "${folderName}" already exists.`
+      ))
+      .catch(() => utils.mkdir(`${insertPath}${folderName}`))
       .then(() => Promise.all([
         utils.read(paths.reducerStub, 'utf8'),
         utils.read(paths.actionStub, 'utf8'),
@@ -44,10 +49,16 @@ program
         ]);
       })
       .then(res => Promise.all([
-        utils.write(`${insertPath}${name}/reducer.js`, res[0]),
-        utils.write(`${insertPath}${name}/actions.js`, res[1]),
-        utils.write(`${insertPath}${name}/selectors.js`, res[2]),
+        utils.write(`${insertPath}${folderName}/reducer.js`, res[0]),
+        utils.write(`${insertPath}${folderName}/actions.js`, res[1]),
+        utils.write(`${insertPath}${folderName}/selectors.js`, res[2]),
       ]))
-      .then(() => utils.success(`State "${name}" successfully created!`))
+      .then(() => utils.success(
+        `State folder successfully created!
+        ==> "${insertPath}${folderName}/"
+        ==> "${insertPath}${folderName}/reducer.js"
+        ==> "${insertPath}${folderName}/actions.js"
+        ==> "${insertPath}${folderName}/selectors.js"`
+      ))
       .catch(utils.exit);
   });


### PR DESCRIPTION
### Overview

This PR allows a user to specify a filename when using the `make:reducer`, `make:action`, `make:selector` commands. This is to allow a developer to ease into the `make` command in case they are using legacy formats.

**New usage**

`redux-cli make:reducer --name=foo` makes a new file named `foo.js`.
### Additional changes

The success messages for all commands now include the path and filename so a developer knows where exactly the new folder / files were created.

Also, the `make:reducer` command now accepts a `--actions` flag in case the developer wants to add in default action types to the single reducer file.

In addition, all file and folder names are now lower + kebab cased.
